### PR TITLE
ignore-empty-activity-description

### DIFF
--- a/lib/timelog/cli.rb
+++ b/lib/timelog/cli.rb
@@ -29,7 +29,9 @@ module Timelog
     def run(*args)
       options, args = parse_command_line_options!(args)
       timelog = ::Timelog::load_stream(@stream)
-      timelog.record_activity(args[0]) unless args.empty?
+      unless args.empty? || args[0].strip.empty?
+        timelog.record_activity(args[0])
+      end
       DailyReport::render(timelog, @output)
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -40,6 +40,15 @@ class CLITest < MiniTest::Unit::TestCase
                  "Time left at work:    8 h 00 min\n",
                  @output.string)
   end
+
+  # Timeout::CLI#run ignores empty activity descriptions.
+  def test_run_with_empty_activity_description
+    @client.run("")
+    assert_equal("Time spent working:   0 h 00 min\n" <<
+                 "Time spent slacking:  0 h 00 min\n" <<
+                 "Time left at work:    8 h 00 min\n",
+                 @output.string)
+  end
 end
 
 


### PR DESCRIPTION
This branch introduces the following changes:
- Empty activity descriptions are ignored.
