### PR TITLE
fix-hour-formatting

### DIFF
--- a/lib/timelog/daily_report.rb
+++ b/lib/timelog/daily_report.rb
@@ -75,7 +75,7 @@ module Timelog
     def self.format_duration(seconds)
       hours = 0
       minutes = seconds / 60
-      if minutes > 60
+      if minutes > 59
         hours = minutes / 60
         minutes = minutes % 60
       end

--- a/test/daily_report_test.rb
+++ b/test/daily_report_test.rb
@@ -105,4 +105,21 @@ class DailyReportTest < MiniTest::Unit::TestCase
                  "Time left at work:    7 h 55 min\n",
                  @output.string)
   end
+
+  # Timelog::DailyReport.render converts the minutes spent on an activity into
+  # a string like 'X h YY min'.  It correctly converts 60 minutes into '1 h 00
+  # min'.
+  def test_render_calculates_hour_boundary
+    today1 = Time.new(2012, 1, 31, 15) # Today at 3:00pm
+    @timelog.record_activity('Arrived', today1)
+    today2 = Time.new(2012, 1, 31, 16) # Today at 4:00pm
+    @timelog.record_activity('Writing a test', today2)
+    Timelog::DailyReport.render(@timelog, @output, Time.new(2012, 1, 31))
+    assert_equal("1 h 00 min   Writing a test\n" <<
+                 "\n" <<
+                 "Time spent working:   1 h 00 min\n" <<
+                 "Time spent slacking:  0 h 00 min\n" <<
+                 "Time left at work:    7 h 00 min\n",
+                 @output.string)
+  end
 end


### PR DESCRIPTION
The time format correctly renders '1 h 00 min' when an activity took
exactly one hour.

Fixes #5.
