### PR TITLE
Add require to CLI to find rest of Timelog module

### DIFF
--- a/lib/timelog/cli.rb
+++ b/lib/timelog/cli.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'timelog'
 
 module Timelog
   # Raised if usage text should be displayed.


### PR DESCRIPTION
The CLI code didn't have any reference to the rest of the timelog code.
